### PR TITLE
Update dropbox.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This is a fork of the dropboxer module by tirah2. This removes the limitation of restricting the selection of specific filetypes, and allows all filetypes to be selected.
+
+------------------------------------
 
 Hi! 
 This is DMkal! If you like my little modules, please offer me a coffee, I would appreciate that a lot and motivate me to do many more modules and quality of life tools! Thank you very much!

--- a/module.json
+++ b/module.json
@@ -3,8 +3,8 @@
   "title": "Dropboxer",
   "description": "Integrate dropbox into foundry for the creation of scenes and tiles and sounds.",
   "version": "1.2.1",
-  "manifest": "https://github.com/tirzah2/dropboxer/releases/latest/download/module.json",
-  "download": "https://github.com/tirzah2/dropboxer/releases/download/1.2.1/module.zip",
+  "old_manifest": "https://github.com/tirzah2/dropboxer/releases/latest/download/module.json",
+  "old_download": "https://github.com/tirzah2/dropboxer/releases/download/1.2.1/module.zip",
   "compatibility": {
     "minimum": 11,
     "verified": 11,
@@ -15,6 +15,11 @@
       "name": "Kaleth",
       "url": "",
       "discord": "DMKal"
+    },
+    {
+      "name": "Butt-Munch (forked)",
+      "discord": "butt.munch",
+      "flags": {}
     }
   ],
   "esmodules": [],

--- a/scripts/dropbox.js
+++ b/scripts/dropbox.js
@@ -127,7 +127,7 @@ function openDropboxChooserForFilePicker(event, inputField) {
     },
     linkType: "preview", // Use "preview" to get the preview link first
     multiselect: false,
-    extensions: ['.jpg', '.jpeg', '.png', '.gif', '.webp'],
+    //extensions: ['.jpg', '.jpeg', '.png', '.gif', '.webp'],
   };
 
   Dropbox.choose(options);


### PR DESCRIPTION
Modified dropbox.js

Eliminated FileType restriction from the Dropbox FilePicker (done by simply commenting out the line where extensions are declared). This assumes that the user is knowledgeable enough to use the appropriate FileType for the appropriate use case (though Foundry won't let you use the wrong FileType anyways). Only the FilePicker function is used in V12. The other functions (TileConfig, audio, folder selection, etc) do not seem to be used, at least on V12, so those functions are untouched.

This can be very useful for adding atypical or large files (mp4's or webm's) to scene backgrounds or tiles. It also expands the use case of this module. This includes using larger music files in playlists, or having assets (beyond just images) generically stored on Dropbox, freeing up the host's network bandwidth as assets will be pulled from Dropbox vs being pulled from the host.

Edit: Corrected improper capitalization in comment